### PR TITLE
register NamespaceParser from new Spring.Template.Velocity.Castle assembly

### DIFF
--- a/test/Spring/Spring.Template.Velocity.Castle.Tests/App.config
+++ b/test/Spring/Spring.Template.Velocity.Castle.Tests/App.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+
+  <configSections>
+    <sectionGroup name="spring">
+      <section name="parsers" type="Spring.Context.Support.NamespaceParsersSectionHandler, Spring.Core"/>
+    </sectionGroup>
+  </configSections>
+
+  <spring>
+    <parsers>
+      <parser type="Spring.Template.Velocity.Config.TemplateNamespaceParser, Spring.Template.Velocity.Castle" />
+    </parsers>
+  </spring>
+  
+</configuration>

--- a/test/Spring/Spring.Template.Velocity.Castle.Tests/Spring.Template.Velocity.Castle.Tests.2010.csproj
+++ b/test/Spring/Spring.Template.Velocity.Castle.Tests/Spring.Template.Velocity.Castle.Tests.2010.csproj
@@ -94,6 +94,7 @@
     <None Include="..\Spring.Template.Velocity.Tests\Template\Velocity\SimpleTemplate.vm">
       <Link>Template\Velocity\SimpleTemplate.vm</Link>
     </None>
+    <None Include="App.config" />
     <None Include="packages.config" />
     <None Include="Template\Velocity\config.properties" />
   </ItemGroup>


### PR DESCRIPTION
This PR addresses the initial issue, but exposes another more tricky one that will need to be addressed (somehow). 

See https://github.com/spring-projects/spring-net/issues/102#issuecomment-80691156 for discussion of this fix (and the next issue that you will have to try to address in order to proceed with this port to Velocity.Castle)
